### PR TITLE
fix MatrixCPU allocate function to make implementation consistent

### DIFF
--- a/test/library/matrix/impl/cpu-matrix.h
+++ b/test/library/matrix/impl/cpu-matrix.h
@@ -29,7 +29,7 @@ public:
     }
 
     static MatrixCPU allocate(int64_t, int64_t, int64_t l_x, int64_t l_y) {
-        return MatrixCPU(l_x, l_y, l_x);
+        return MatrixCPU(l_x, l_y, l_y);
     }
 
     MatrixCPU query(int64_t x, int64_t y, int64_t l_x, int64_t l_y) {

--- a/test/test-cpu-matrix.cpp
+++ b/test/test-cpu-matrix.cpp
@@ -28,11 +28,11 @@ TEST(LoweringCPU, MatrixCPUAdd) {
     run.compile(test::cpuRunner(std::vector<std::string>{"matrix"}));
 
     int64_t row_val = 10;
-    int64_t col_val = 10;
+    int64_t col_val = 20;
 
-    impl::MatrixCPU a(row_val, col_val, row_val);
+    impl::MatrixCPU a(row_val, col_val, col_val);
     a.vvals(2.0f);
-    impl::MatrixCPU b(row_val, col_val, row_val);
+    impl::MatrixCPU b(row_val, col_val, col_val);
 
     int64_t l_x_val = 5;
     int64_t l_y_val = 5;


### PR DESCRIPTION
Makes the implementation of `MatrixCPU` such that the `row` param is the number of rows in the matrix and the `col` param is the number of cols. To make `allocate` consistent with this interpretation, `lda` needs to be set to `l_y` (the width of the matrix).